### PR TITLE
Styling enhancements

### DIFF
--- a/easyedit.js
+++ b/easyedit.js
@@ -30,6 +30,7 @@ class EasyEdit
     {
         this.display = this.object.style.display;
         this.replace = document.createElement('input');
+        this.replace.setAttribute('type', 'text');
         this.replace.style.display = 'none';
         this.replace.addEventListener('change', this.change.bind(this));
         this.replace.addEventListener('input', this.input.bind(this));

--- a/easyedit.js
+++ b/easyedit.js
@@ -31,11 +31,6 @@ class EasyEdit
         this.display = this.object.style.display;
         this.replace = document.createElement('input');
         this.replace.style.display = 'none';
-        const styles = this.options.styles || {};
-        for (let key in styles)
-        {
-            this.replace.style[key] = styles[key];
-        }
         this.replace.addEventListener('change', this.change.bind(this));
         this.replace.addEventListener('input', this.input.bind(this));
         this.replace.addEventListener('keydown', this.key.bind(this));
@@ -47,6 +42,11 @@ class EasyEdit
         this.replace.style.font = window.getComputedStyle(this.object, null).getPropertyValue('font');
         this.replace.style.margin = window.getComputedStyle(this.object, null).getPropertyValue('margin');
         this.replace.style.padding = window.getComputedStyle(this.object, null).getPropertyValue('padding');
+        const styles = this.options.styles || {};
+        for (let key in styles)
+        {
+            this.replace.style[key] = styles[key];
+        }
         this.original = this.replace.value = this.object.innerText;
         this.object.style.display = 'none';
         this.replace.style.display = this.display;


### PR DESCRIPTION
Hi,

Here are some small changes that enhance the styling of the input: 

* creating an `<input type="text>` instead of simply `<input>` lets external css frameworks like zurb Foundation style  the input, rather than having the default browser's styling.
* apply the custom styles after the default ones (this way a custom `height: auto` does not get overriden).

P.S. Thanks for open sourcing easyedit, it's very convenient to work with.